### PR TITLE
Feat: Add test runner script and assorted fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,8 @@ jobs:
 
       - name: Run Tests
         run: |
-          xcodebuild clean test \
-            -project AtomicArch.xcodeproj \
-            -scheme AtomicArch \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' \
-            -enableCodeCoverage YES | xcpretty
+          chmod +x Scripts/run-tests.rb
+          ruby Scripts/run-tests.rb AtomicArch AtomicArch.xcodeproj | xcpretty
 
       - name: Upload Test Results
         if: always()

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -53,11 +53,9 @@ jobs:
 
       - name: Build and test
         run: |
-          xcodebuild clean test \
-            -project AtomicArch.xcodeproj \
-            -scheme ${{ env.SCHEME }} \
-            -destination 'platform=${{ env.PLATFORM }} Simulator,name=iPhone 16 Pro,OS=latest' \
-            -enableCodeCoverage YES | xcpretty
+          chmod +x Scripts/run-tests.rb
+          xcodebuild clean build -project AtomicArch.xcodeproj -scheme ${{ env.SCHEME }} -destination 'platform=${{ env.PLATFORM }} Simulator,name=iPhone 16 Pro,OS=latest' | xcpretty
+          ruby Scripts/run-tests.rb ${{ env.SCHEME }} AtomicArch.xcodeproj | xcpretty
       
       - name: Upload Test Results
         if: always()

--- a/AtomicArch/Application/AppConfig.swift
+++ b/AtomicArch/Application/AppConfig.swift
@@ -13,11 +13,11 @@ struct AppConfig {
   }()
 
   init() {
-    let logginNetworkIntercetor = LoggingInterceptor(
+    let loggingNetworkInterceptor = LoggingInterceptor(
       logger: logger
     )
-    let interceptorChain = NetworkInterceptorChain(interceptors: [logginNetworkIntercetor])
-    let configuration = NetworkServiceImpl.Configuation(
+    let interceptorChain = NetworkInterceptorChain(interceptors: [loggingNetworkInterceptor])
+    let configuration = NetworkServiceImpl.Configuration(
       baseURL: Environment.baseURL,
       defaultHeaders: ["Content-Type": "application/json"]
     )

--- a/AtomicArch/Data/Models/User.swift
+++ b/AtomicArch/Data/Models/User.swift
@@ -17,10 +17,24 @@ struct UserResponse: Decodable {
 extension UserResponse {
   func toDomain() -> UserEntity {
     UserEntity(
-      id: UUID(),
+      id: Self.uuidFromAPIId(self.id),
       login: self.login ?? "",
       avatarUrl: self.avatarUrl ?? "",
       htmlUrl: self.htmlUrl ?? ""
     )
+  }
+
+  private static func uuidFromAPIId(_ id: Int) -> UUID {
+    UUID(uuid: (
+      0, 0, 0, 0, 0, 0, 0, 0,
+      UInt8((id >> 56) & 0xFF),
+      UInt8((id >> 48) & 0xFF),
+      UInt8((id >> 40) & 0xFF),
+      UInt8((id >> 32) & 0xFF),
+      UInt8((id >> 24) & 0xFF),
+      UInt8((id >> 16) & 0xFF),
+      UInt8((id >> 8) & 0xFF),
+      UInt8(id & 0xFF)
+    ))
   }
 }

--- a/AtomicArch/Domain/Entities/UserEntity.swift
+++ b/AtomicArch/Domain/Entities/UserEntity.swift
@@ -7,6 +7,6 @@ struct UserEntity: Identifiable, Equatable {
   let htmlUrl: String
 
   static func == (lhs: UserEntity, rhs: UserEntity) -> Bool {
-    lhs.login == rhs.login
+    lhs.id == rhs.id && lhs.login == rhs.login
   }
 }

--- a/AtomicArch/Features/Users/Detail/UserDetailViewController.swift
+++ b/AtomicArch/Features/Users/Detail/UserDetailViewController.swift
@@ -390,10 +390,7 @@ final class UserDetailViewController: UIViewController, View {
   }
 
   @objc private func backButtonTapped() {
-    print("DEBUG: Back button tapped")
-    print("DEBUG: Delegate is nil? \(self.delegate == nil)")
     self.delegate?.userDetailViewControllerDidFinish(self)
-    print("DEBUG: After delegate call")
   }
 
   private func handleViewState(_ state: ViewModelType.ViewState) {
@@ -457,7 +454,7 @@ final class UserDetailViewController: UIViewController, View {
             }
           }
         } catch {
-          print("Error loading avatar: \(error)")
+          // Silently ignore avatar load failures
         }
       }
     }

--- a/AtomicArch/Features/Users/List/Cells/UserCell.swift
+++ b/AtomicArch/Features/Users/List/Cells/UserCell.swift
@@ -94,7 +94,7 @@ final class UserCell: UITableViewCell {
             }
           }
         } catch {
-          print("Error loading avatar: \(error)")
+          // Silently ignore avatar load failures
         }
       }
     }

--- a/AtomicArchTests/Helpers/TestData.swift
+++ b/AtomicArchTests/Helpers/TestData.swift
@@ -1,4 +1,4 @@
-@testable import Atomic_B
+@testable import AtomicArch
 import Foundation
 
 // Helper for generating test data for tests

--- a/AtomicArchTests/Mocks/UserRepositoryMock.swift
+++ b/AtomicArchTests/Mocks/UserRepositoryMock.swift
@@ -1,5 +1,5 @@
 
-@testable import Atomic_B
+@testable import AtomicArch
 import Foundation
 
 class UserRepositoryMock: UserRepository {

--- a/AtomicArchTests/Mocks/UserUseCaseMock.swift
+++ b/AtomicArchTests/Mocks/UserUseCaseMock.swift
@@ -1,5 +1,5 @@
 
-@testable import Atomic_B
+@testable import AtomicArch
 
 class UserUseCaseMock: UserUseCase {
   init() {}

--- a/AtomicArchTests/Unit/UseCase/UserUseCaseImplTests.swift
+++ b/AtomicArchTests/Unit/UseCase/UserUseCaseImplTests.swift
@@ -1,4 +1,4 @@
-@testable import Atomic_B
+@testable import AtomicArch
 import Networking
 import XCTest
 
@@ -10,6 +10,12 @@ final class UserUseCaseImplTests: XCTestCase {
     super.setUp()
     self.repository = UserRepositoryMock()
     self.useCase = UserUseCaseImpl(repository: self.repository)
+  }
+
+  override func tearDown() {
+    self.repository = nil
+    self.useCase = nil
+    super.tearDown()
   }
 
   func test_getListUser_success() async throws {

--- a/AtomicArchTests/Unit/ViewModel/ListUserGitHubViewModelTests.swift
+++ b/AtomicArchTests/Unit/ViewModel/ListUserGitHubViewModelTests.swift
@@ -1,4 +1,4 @@
-@testable import Atomic_B
+@testable import AtomicArch
 import Combine
 import Networking
 import XCTest
@@ -125,8 +125,9 @@ final class ListUserGitHubViewModelTests: XCTestCase {
     // Act: Load more with the last user
     await self.sut.loadUsers(since: 2)
 
-    // Assert: user2 should not be duplicated
-    XCTAssertNotEqual(self.sut.users[1].login, "user3")
+    // Assert: user2 should not be duplicated; we should have 3 unique users
+    XCTAssertEqual(self.sut.users.count, 3)
+    XCTAssertEqual(self.sut.users.map(\.login), ["user1", "user2", "user3"])
   }
 
   func test_loadUsers_retryAfterFailure() async {

--- a/AtomicArchTests/Unit/ViewModel/UserDetailViewModelTests.swift
+++ b/AtomicArchTests/Unit/ViewModel/UserDetailViewModelTests.swift
@@ -1,4 +1,4 @@
-@testable import Atomic_B
+@testable import AtomicArch
 import Combine
 @testable import Networking
 import XCTest

--- a/AtomicCore/Sources/AtomicCore/Coordinator/Coordinator.swift
+++ b/AtomicCore/Sources/AtomicCore/Coordinator/Coordinator.swift
@@ -39,7 +39,8 @@ public extension Coordinator {
   private func removeChild(_ child: Coordinator) {
     guard
       let index = children.firstIndex(
-        where: { $0 === child })
+        where: { $0 === child }
+      )
     else {
       return
     }

--- a/AtomicCore/Sources/AtomicCore/Router/NavigationRouter.swift
+++ b/AtomicCore/Sources/AtomicCore/Router/NavigationRouter.swift
@@ -27,7 +27,8 @@ open class NavigationRouter: NSObject {
   open func dismiss(animated: Bool) {
     guard let routerRootController else {
       self.navigationController.popToRootViewController(
-        animated: animated)
+        animated: animated
+      )
       return
     }
     self.performOnDismissed(for: routerRootController)

--- a/AtomicCore/Tests/AtomicCoreTests/AtomicCoreTests.swift
+++ b/AtomicCore/Tests/AtomicCoreTests/AtomicCoreTests.swift
@@ -2,7 +2,7 @@
 import XCTest
 
 final class AtomicCoreTests: XCTestCase {
-  func testExample() throws {
+  func testExample() {
     // XCTest Documentation
     // https://developer.apple.com/documentation/xctest
 

--- a/Networking/README.md
+++ b/Networking/README.md
@@ -48,7 +48,7 @@ struct MyEndpoint: Target {
 ```swift
 import Networking
 
-let config = NetworkService.Configuation(
+let config = NetworkServiceImpl.Configuration(
     baseURL: URL(string: "https://api.example.com")!,
     timeoutInterval: 30,
     defaultHeaders: ["Content-Type": "application/json"]

--- a/Networking/Sources/Networking/NetworkServiceImpl.swift
+++ b/Networking/Sources/Networking/NetworkServiceImpl.swift
@@ -2,7 +2,7 @@ import Foundation
 import OSLog
 
 public final class NetworkServiceImpl {
-  public struct Configuation {
+  public struct Configuration {
     public let baseURL: URL
     public let timeoutInterval: TimeInterval
     public let defaultHeaders: [String: String]
@@ -14,13 +14,13 @@ public final class NetworkServiceImpl {
     }
   }
 
-  public let configuration: Configuation
+  public let configuration: Configuration
   public let session: NetworkSessionProtocol
   public let interceptorChain: NetworkInterceptorChain
   public let networkMonitor: NetworkMonitoring
 
   public init(
-    configuration: Configuation,
+    configuration: Configuration,
     session: NetworkSessionProtocol,
     interceptorChain: NetworkInterceptorChain,
     networkMonitor: NetworkMonitoring

--- a/Networking/Tests/NetworkingTests/NetworkInterceptorChainTests.swift
+++ b/Networking/Tests/NetworkingTests/NetworkInterceptorChainTests.swift
@@ -27,9 +27,9 @@ final class NetworkInterceptorChainTests: XCTestCase {
 
   // MARK: - Request Interception Tests
 
-  func test_interceptRequest_callsAllInterceptorsInOrder() {
+  func test_interceptRequest_callsAllInterceptorsInOrder() throws {
     // given
-    var request = URLRequest(url: URL(string: "https://example.com")!)
+    var request = try URLRequest(url: XCTUnwrap(URL(string: "https://example.com")))
 
     // when
     self.sut.interceptRequest(&request)
@@ -40,9 +40,9 @@ final class NetworkInterceptorChainTests: XCTestCase {
     }
   }
 
-  func test_interceptRequest_passesModifiedRequestToNextInterceptor() {
+  func test_interceptRequest_passesModifiedRequestToNextInterceptor() throws {
     // given
-    var request = URLRequest(url: URL(string: "https://example.com")!)
+    var request = try URLRequest(url: XCTUnwrap(URL(string: "https://example.com")))
     request.addValue("test", forHTTPHeaderField: "Custom")
 
     // when
@@ -54,9 +54,9 @@ final class NetworkInterceptorChainTests: XCTestCase {
 
   // MARK: - Response Interception Tests
 
-  func test_interceptResponse_callsAllInterceptorsInOrder() {
+  func test_interceptResponse_callsAllInterceptorsInOrder() throws {
     // given
-    let response = HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: 200, httpVersion: nil, headerFields: nil)
+    let response = try HTTPURLResponse(url: XCTUnwrap(URL(string: "https://example.com")), statusCode: 200, httpVersion: nil, headerFields: nil)
     let data = "test".data(using: .utf8)
 
     // when

--- a/README.md
+++ b/README.md
@@ -311,13 +311,18 @@ AtomicArchTests/
 │   │   ├── ListUserGitHubViewModelTests.swift
 │   │   └── UserDetailViewModelTests.swift
 │   ├── UseCase/
+│   │   └── UserUseCaseImplTests.swift
 │   └── Repository/
+│       └── UserRepositoryImplTests.swift
 ├── Helpers/
-│   └── TestData.swift
+│   ├── TestData.swift
+│   └── XCTest+Async.swift
 └── Mocks/
     ├── UserUseCaseMock.swift
     └── UserRepositoryMock.swift
 ```
+
+A test plan is provided: `AtomicBTestPlan.xctestplan`.
 
 ### 3. Testing Principles
 - **Isolation**: Each test is independent with proper mocking
@@ -365,18 +370,24 @@ The project uses GitHub Actions for continuous integration:
    ```bash
    git clone https://github.com/phanquangcong/AtomicArch.git
    cd AtomicArch
-   xcodebuild -resolvePackageDependencies
+   xcodebuild -resolvePackageDependencies -project AtomicArch.xcodeproj
    ```
 
 3. **Running the App**
    ```bash
-   xcodebuild -scheme AtomicArch -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.5' build
+   xcodebuild -scheme AtomicArch -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' build
    ```
+   Or open the project in Xcode, choose the **AtomicArch** scheme and an iOS 18.5+ simulator, then Run (⌘R).
 
 4. **Running Tests**
    ```bash
-   xcodebuild test -scheme AtomicArch -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.5'
+   ruby Scripts/run-tests.rb
    ```
+   The script picks an available simulator (booted first, else first iPhone). Or run directly:
+   ```bash
+   xcodebuild test -scheme AtomicArch -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest'
+   ```
+   In Xcode you can use the test plan `AtomicBTestPlan.xctestplan` or run tests with ⌘U.
 
 ## 🧹 Linting & Formatting
 
@@ -437,8 +448,8 @@ swiftformat .
 # Lint
 swiftlint lint --config .swiftlint.yaml
 
-# Tests
-xcodebuild test -scheme AtomicArch -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.5'
+# Tests (uses first available simulator)
+ruby Scripts/run-tests.rb
 ```
 
 ### 4) Create a PR

--- a/Scripts/run-tests.rb
+++ b/Scripts/run-tests.rb
@@ -1,0 +1,52 @@
+#!/usr/bin/env ruby
+# Run tests on an available iOS simulator.
+# Picks the first Booted device, or the first available iPhone if none are booted.
+
+scheme = ARGV[0] || "AtomicArch"
+project = ARGV[1] || "AtomicArch.xcodeproj"
+extra_args = ARGV[2..] || []
+
+uuid_regex = /[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}/
+
+destination = nil
+devices_output = `xcrun simctl list devices available 2>/dev/null`
+
+# Prefer booted iPhone
+devices_output.each_line do |line|
+  next unless line =~ /iPhone/i && line.include?("Booted")
+  if (match = line.match(uuid_regex))
+    destination = "id=#{match[0]}"
+    puts "Using booted simulator: #{match[0]}"
+    break
+  end
+end
+
+# Fallback to first available iPhone
+if destination.nil?
+  devices_output.each_line do |line|
+    next unless line =~ /iPhone/i
+    if (match = line.match(uuid_regex))
+      destination = "id=#{match[0]}"
+      puts "Using first available iPhone: #{match[0]}"
+      break
+    end
+  end
+end
+
+# Fallback to generic destination
+if destination.nil?
+  destination = "platform=iOS Simulator,name=iPhone 16 Pro,OS=latest"
+  puts "No specific simulator found, using: #{destination}"
+end
+
+puts "Running tests with destination: #{destination}"
+
+cmd = [
+  "xcodebuild", "test",
+  "-project", project,
+  "-scheme", scheme,
+  "-destination", destination,
+  "-enableCodeCoverage", "YES"
+] + extra_args
+
+exec(*cmd)


### PR DESCRIPTION
Add a Ruby test runner (Scripts/run-tests.rb) and update GitHub Actions to use it to pick an available simulator, improving CI/test reliability.

Fix typos and API/implementation mismatches: rename NetworkServiceImpl.Configuation → Configuration (and usages), correct logging interceptor variable name, and update README examples.

Stabilize domain models and behavior: derive UUID deterministically from API id in UserResponse, make UserEntity equality compare id and login, and suppress noisy debug prints when loading avatars or tapping back.

Update unit tests and mocks: fix test imports (Atomic_B → AtomicArch), add/adjust tests (tearDown, stronger assertions, endpoint path capture tests), rename test folder Repository, and adjust networking tests' error assertions.

Misc: add README updates describing the test script and test plan, and small formatting/comment fixes.